### PR TITLE
私聊消息；在Python3.10下运行

### DIFF
--- a/nakuru/application.py
+++ b/nakuru/application.py
@@ -1,3 +1,4 @@
+import sys
 import aiohttp
 import asyncio
 import inspect
@@ -174,7 +175,7 @@ class CQHTTP(CQHTTP_Protocol):
     
     def run(self):
         loop = asyncio.get_event_loop()
-        self.queue = asyncio.Queue(loop=loop)
+        self.queue = asyncio.Queue(loop=loop) if sys.version_info.minor < 10 else asyncio.Queue()
         loop.create_task(self.ws_event())
         loop.create_task(self.event_runner())
 

--- a/nakuru/protocol.py
+++ b/nakuru/protocol.py
@@ -11,20 +11,22 @@ class CQHTTP_Protocol:
 
     async def sendFriendMessage(self,
                                 user_id: int,
-                                group_id: int,
                                 message: T.Union[str, list],
+                                group_id: T.Optional[int] = None,
                                 auto_escape: bool = False) -> T.Union[BotMessage, bool]:
         if isinstance(message, list):
             _message = ""
             for chain in message:
                 _message += chain.toString()
             message = _message
-        result = await fetch.http_post(f"{self.baseurl_http}/send_private_msg", {
+        payload = {
             "user_id": user_id,
-            "group_id": group_id,
             "message": message,
             "auto_escape": auto_escape
-        })
+        }
+        if group_id:
+            payload["group_id"] = group_id
+        result = await fetch.http_post(f"{self.baseurl_http}/send_private_msg", payload)
         if result["status"] == "ok":
             return BotMessage.parse_obj(result["data"])
         return False


### PR DESCRIPTION
提交两处小改动。

### 私聊消息

根据 [go-cqhttp 的 API 文档](https://docs.go-cqhttp.org/api/#%E5%8F%91%E9%80%81%E7%A7%81%E8%81%8A%E6%B6%88%E6%81%AF)，调用 `send_friend_msg` 时，`group_id` 是用于发起临时会话的，如果向好友私聊消息，则不需要 `group_id`。因此将其设置为可选的字段。

### `Queue`

Python 3.10 移除了 `loop` 参数，保留 `loop` 参数则无法运行。